### PR TITLE
No longer require API token for export

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,2 @@
 export SLACK_TEAM=
 export SLACK_COOKIE=
-export SLACK_API_TOKEN=
-export EMOJI_DIR=

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Prepare a directory that contains an image for each emoji you want to create. Re
 
 Clone the project, create a new virtualenv, and install the prereqs:
 
+`libxml` is required on your system, if you'd like to use the bulk export script.
+
 ```bash
 git clone https://github.com/smashwilson/slack-emojinator.git
 cd slack-emojinator

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ python upload.py ${EMOJI_DIR}/*.png
 
 ## Exporting Emoji
 
-A Slack API token and an export director are needed for the export. They can be added to the `.env` file and sourced.
+To export emoji, simply use `export.py` and specify an emoji directory:
 
 ```bash
 source .env
-python export.py ${EMOJI_DIR}/
+python export.py path-to-destination/
 ```

--- a/export.py
+++ b/export.py
@@ -4,47 +4,59 @@
 # https://github.com/smashwilson/slack-emojinator
 
 from __future__ import print_function
-from slacker import Slacker
+
+import requests
+import lxml.html
 
 import argparse
 import os
-import requests
 import shutil
+
+from upload import _session
 
 
 def _argparse():
     parser = argparse.ArgumentParser(
-        description='Bulk import of emoji froma slack team'
+        description='Bulk import of emoji from a slack team'
     )
     parser.add_argument(
-        '--directory', '-d',
-        default=os.getenv('EMOJI_DIR'),
-        help='Defaults to the $EMOJI_DIR environment variable.'
+        'directory',
+        help='Where do we store downloaded emoji?'
     )
     parser.add_argument(
-        '--slack-api-token', '-s',
-        default=os.getenv('SLACK_API_TOKEN'),
-        help='Defaults to the $SLACK_API_TOKEN environment variable.'
+        '--team-name', '-t',
+        default=os.getenv('SLACK_TEAM'),
+        help='Defaults to the $SLACK_TEAM environment variable.'
+    )
+    parser.add_argument(
+        '--cookie', '-c',
+        default=os.getenv('SLACK_COOKIE'),
+        help='Default sto the $SLACK_COOKIE environment variable.'
     )
     args = parser.parse_args()
     return args
 
+
 def main():
     args = _argparse()
-    download_emoji(args.directory, args.slack_api_token)
 
-def download_emoji(directory, slack_api_token):
-    print("slack API token: %s" % slack_api_token)
-    slack = Slacker(slack_api_token)
-    if not os.path.exists(directory):
-        os.makedirs(directory)
-    emojis = slack.emoji.list()
-    for emoji_name, emoji_url in emojis.body['emoji'].items():
-        if "alias" not in emoji_url:
+    if not os.path.exists(args.directory):
+        os.makedirs(args.directory)
+
+    session = _session(args)
+    resp = session.get(session.url)
+    tree = lxml.html.fromstring(resp.text)
+    urls = tree.xpath(r'//td[@headers="custom_emoji_image"]/span/@data-original')
+    names = [u.split('/')[-2] for u in urls]
+
+    for emoji_name, emoji_url in zip(names, urls):
+        if "alias" not in emoji_url:  # this does not seem necessary ...
             file_extension = emoji_url.split(".")[-1]
-            request = requests.get(emoji_url, stream=True)
+            request = session.get(emoji_url, stream=True)
             if request.status_code == 200:
-                with open('%s/%s.%s' % (directory, emoji_name, file_extension), 'wb') as out_file:
+                filename = '%s/%s.%s' % (args.directory, emoji_name,
+                                         file_extension)
+                with open(filename, 'wb') as out_file:
                     shutil.copyfileobj(request.raw, out_file)
                 del request
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 beautifulsoup4>=4.4, <5.0
 requests>=2.5.3, <3.0
-slacker==0.9.30
+lxml==3.7.3


### PR DESCRIPTION
Slack API tokens are difficult to come by on free teams, since custom integrations are limited. Therefore exporting with just a cookie might be preferable. This pull request does that, using `lxml` (which I ~~prefer over~~ am more experienced with than bs4) to scrape the emoji from the custom emoji page.

I'm not sure whether this change is valuable to you, but it certainly is to me, since I don't have API keys for some of my teams. Take it or leave it :smile: