### PR TITLE
A little fix to upload.py

### DIFF
--- a/upload.py
+++ b/upload.py
@@ -80,7 +80,7 @@ def main():
 def get_current_emoji_list(session):
     r = session.get(session.url)
     r.raise_for_status()
-    x = re.findall("data-emoji-name=\"(.*)\"", r.text)
+    x = re.findall("data-emoji-name=\"(.*?)\"", r.text)
     return x
 
 


### PR DESCRIPTION
get_current_emoji_list function had a greedy quantifier in regexp: "data-emoji-name=\"(.*)\""
I.e. for string like
`data-emoji-name="parrot" data-action="emoji.remove"`
it returns following result:
`parrot" data-action="emoji.remove`

In case of lazy quantifier ("data-emoji-name=\"(.*?)\"") the result will be correct:`parrot`