### PR TITLE
WIP Add emoji_dir argument to open and read filenames from dir

### DIFF
--- a/.python-version
+++ b/.python-version
@@ -1,0 +1,1 @@
+slack-emojinator

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4>=4.4, <5.0
 requests>=2.5.3, <3.0
-lxml==3.7.3
+#lxml==3.7.3
 aiohttp==2.3.1
 idna-ssl==1.1.0

--- a/upload.py
+++ b/upload.py
@@ -68,11 +68,8 @@ def _argparse():
         'Defaults to the $EMOJI_NAME_SUFFIX environment variable.'
     )
     parser.add_argument(
-        'slackmoji_files',
-        nargs='+',
-        help=('Paths to slackmoji, e.g. if you '
-              'unzipped http://cultofthepartyparrot.com/parrots.zip '
-              'in your home dir, then use ~/parrots/*'),
+        '--slackmoji-dir',
+       help='Directory containing Slackmojis to open and bulk upload from'
     )
     args = parser.parse_args()
     if not args.team_name:
@@ -112,7 +109,11 @@ def main():
     existing_emojis = get_current_emoji_list(session)
     uploaded = 0
     skipped = 0
-    for filename in args.slackmoji_files:
+    emoji_files = [
+        os.path.join(args.slackmoji_dir, filename)
+        for filename in os.listdir(args.slackmoji_dir)
+    ]
+    for filename in emoji_files:
         print("Processing {}.".format(filename))
         emoji_name = '{}{}{}'.format(
             args.prefix.strip(),


### PR DESCRIPTION
### Instigating Issue

I tried to upload 22,000+ emojis and received an OS error.

### Description

Due to https://codeyarns.com/2017/03/07/size-of-argument-and-environment-lists-exceeds-limit/ if the `${EMOJI_DIR}/*.png` glob-expanded arg list is over a certain size the app will not run. The Linux kernel sets a `getconf` key of `ARG_MAX` which defines the "size of argument and environment lists" limit. Unfortunately this conf value does not appear to be easily modified by a user.

### Solution

Allow an optional argument of `emoji_dir` with `--emoji-dir`. If present, the filenames are read from the dir and absolute paths to them created. The resulting list is then iterated over much like `args.slackmoji_files` and the rest of the app will execute the same.

### Note

Currently this is WIP- I have confirmed that it works for my use-case but would like to clean up the code some more, add back in the `args.slackmoji_files` method of passing in emoji filepaths, and write some tests to cover the new feature.