### PR TITLE
Accept dirs as well as single files on command line, and also accept api_token via input if scraping it fails.

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -85,6 +85,7 @@
         },
         "lxml": {
             "hashes": [
+                "sha256:fa071559f14bd1e92077b1b5f6c22cf09756c6de7139370249eb372854ce51e6",
                 "sha256:0a103253a94cdad86028d273aaebb8b30c75fdf009c23e52cdc8ce88429fd326",
                 "sha256:10399bececdb67f0d9251ecf2dda2abf6ddeee6096741754356f1a3715c8c830",
                 "sha256:12e348eb57fb79ccf91a49b7b937c49a5bbe1d73ba75589674b76a56d064bda0",
@@ -115,7 +116,7 @@
                 "sha256:feb2144c2ae4035ad57165dd22bdc93b1389158a985c0497a096d39e2b2cd67b"
             ],
             "index": "pypi",
-            "version": "==4.1.0"
+            "version": "==4.5.0"
         },
         "multidict": {
             "hashes": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4>=4.4, <5.0
 requests>=2.5.3, <3.0
-lxml==3.7.3
+lxml==4.5.0
 aiohttp==2.3.1
 idna-ssl==1.1.0


### PR DESCRIPTION
Just made these changes to my fork in order to facilitate the uploading of over 19,000 emojis from a directory that I downloaded from my old workspace. Committing this upstream so that it can be helpful to others. Thanks for your initial work on this!